### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -25,7 +25,7 @@ class action_plugin_poldek extends DokuWiki_Action_Plugin {
 	/**
 	 * Register its handlers with the dokuwiki's event controller
 	 */
-	function register(&$controller) {
+	function register(Doku_Event_Handler $controller) {
 		$controller->register_hook('INDEXER_TASKS_RUN', 'BEFORE', $this, 'cron', array());
 		$controller->register_hook('PARSER_CACHE_USE','BEFORE', $this, 'cache');
 	}

--- a/syntax.php
+++ b/syntax.php
@@ -42,7 +42,7 @@ class syntax_plugin_poldek extends DokuWiki_Syntax_Plugin {
 	/**
 	 * Handle the match
 	 */
-	public function handle($match, $state, $pos, &$handler) {
+	public function handle($match, $state, $pos, Doku_Handler $handler) {
 		$raw = substr($match, 9, -2);
 
 		$data = array('pkg' => $raw);
@@ -52,7 +52,7 @@ class syntax_plugin_poldek extends DokuWiki_Syntax_Plugin {
 	/**
 	 * Create output
 	 */
-	public function render($format, &$renderer, $data) {
+	public function render($format, Doku_Renderer $renderer, $data) {
 		if ($format == "metadata") {
 			// add packages to metadata
 			$packages = &$renderer->meta["plugin_" . $this->getPluginName()];


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
